### PR TITLE
Add Stream Info Doc

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -1,6 +1,6 @@
 # Welcome
 
-This is the website hosting all of the Glimesh API documentation.  If you have any questions let us know in our [Discord](https://discord.gg/Glimesh)!
+This is the website hosting all of the Glimesh API documentation.  If you have any questions let us know in our [Discord](https://glimesh.tv/s/discord)!
 
 The API docs are hosted [here](https://glimesh.github.io/api-docs/).
 
@@ -19,4 +19,4 @@ This documentation is a work in progress. We will do our best to keep this updat
 Links you may find useful:
  - [Glimesh developer applications](https://glimesh.tv/users/settings/applications)
  - [Create API requests on Glimesh](https://glimesh.tv/api) (Old API)
- - Our developer channel in [Discord](https://discord.gg/Glimesh)
+ - Our developer channel in [Discord](https://glimesh.tv/s/discord)

--- a/content/_index.md
+++ b/content/_index.md
@@ -4,7 +4,7 @@ title: Home
 
 # Welcome
 
-This is the website hosting all of the Glimesh API documentation.  If you have any questions let us know in our [Discord](https://discord.gg/Glimesh)!
+This is the website hosting all of the Glimesh API documentation.  If you have any questions let us know in our [Discord](https://glimesh.tv/s/discord)!
 
 ## Structure
 
@@ -38,4 +38,4 @@ Not seeing what you are looking for? Consider adding a tutorial for it or talkin
 Links you may find useful:
  - [Glimesh developer applications](https://glimesh.tv/users/settings/applications)
  - [Create API requests on Glimesh without a dev environment](docs/api/api-explorer) (Old API)
- - Our dev-questions channel in [Discord](https://discord.gg/Glimesh)
+ - Our dev-questions channel in [Discord](https://glimesh.tv/s/discord)

--- a/content/docs/Authentication/AccessToken/AccessToken.md
+++ b/content/docs/Authentication/AccessToken/AccessToken.md
@@ -45,7 +45,7 @@ Send a POST request with the URL above replacing the code,redirect url, client I
 }
 ```
 
-Now you can query the Glimesh API on behalf of a user. This token will expire after a few hours so you need to refresh it or ask the user for a new one. If you have any questions talk to us in the #dev-questions channel in our [Discord](https://discord.gg/Glimesh).
+Now you can query the Glimesh API on behalf of a user. This token will expire in 24 hours so you need to refresh it or ask the user for a new one. If you have any questions talk to us in the #dev-questions channel in our [Discord](https://glimesh.tv/s/discord).
 
 > Ready to refresh your token? Continue with OAuth [here](/api-docs/docs/authentication/refreshtoken/refreshtoken/)
 
@@ -73,6 +73,6 @@ This is a request error. Some part of your URL is not necessary or missing. Ensu
 
 `Error: 401 Unauthorized. You must be logged in to access the API.`
 
-This is an authentication issue. This is commonly seen when querying the API but I added it here because it most likely means you must request another token. You must renew or request a new token and send the API request to Glimesh properly.  Tokens expire after a few hours unless they are renewed.
+This is an authentication issue. This is commonly seen when querying the API but I added it here because it most likely means you must request another token. You must renew or request a new token and send the API request to Glimesh properly.  Tokens expire daily unless they are renewed.
 
-> Stuck with something? Talk to us in [Discord](https://discord.gg/Glimesh). We would be happy to help you!
+> Stuck with something? Talk to us in [Discord](https://glimesh.tv/s/discord). We would be happy to help you!

--- a/content/docs/Authentication/AccessToken/ClientCredentials.md
+++ b/content/docs/Authentication/AccessToken/ClientCredentials.md
@@ -28,8 +28,8 @@ Glimesh will respond with:
 "token_type":  "bearer"
 }
 ```
-The access token received will allow us to make requests as if we were using a normal access token. We have permissions for all the scopes and have access to any user specific properties. The token generated will expire in 6 hours just like a normal token. Unlike normal tokens, this cannot be refreshed. As with all auth information you must keep this private.
+The access token received will allow us to make requests as if we were using a normal access token. We have permissions for all the scopes and have access to any user specific properties. The token generated will expire in 24 hours just like a normal token. Unlike normal tokens, this cannot be refreshed. As with all auth information you must keep this private.
 
 > If you don't request any scopes you automatically have access to every scope. If you **do** request a scope you only have access to the scopes that you requested.
 
-If you have any questions talk to us in the #dev-questions channel in our [Discord](https://discord.gg/Glimesh).
+If you have any questions talk to us in the #dev-questions channel in our [Discord](https://glimesh.tv/s/discord).

--- a/content/docs/Authentication/AccessToken/NodeJS/Node Access Token.md
+++ b/content/docs/Authentication/AccessToken/NodeJS/Node Access Token.md
@@ -139,7 +139,7 @@ You should see a confirmation message in your browser. The server is now sending
 
 ![Imgur](https://i.imgur.com/67sv2eV.png)
 
-You can use the *access_token* to query the API on the users behalf. This will expire after a few hours so you will need to refresh the token or get a new one.  If you have any question talk to us in the #dev-questions channel in our [Discord](https://discord.gg/Glimesh).  We would love to hear what you are making!
+You can use the *access_token* to query the API on the users behalf. This will expire in 24 hours so you will need to refresh the token or get a new one.  If you have any question talk to us in the #dev-questions channel in our [Discord](https://glimesh.tv/s/discord).  We would love to hear what you are making!
 
 The full file can be found here.
 

--- a/content/docs/Authentication/AccessToken/pkceAuth.md
+++ b/content/docs/Authentication/AccessToken/pkceAuth.md
@@ -126,6 +126,6 @@ When Glimesh receives your request they will send back an access and refresh tok
 ```
 > Glimesh will send an error in JSON format if your request has an error. Keep in mind that all credentials must be accurate and you must request a token within 1 minute of the user authorizing your app. You need to include the code **verifier**, not the challenge!
 
-You can use the access token for 6 hours. When it expires you need to request a new one with your refresh token. We have a guide on refreshing tokens which can be found [here](/api-docs/docs/authentication/refreshtoken/refreshtoken).
+You can use the access token for 24 hours. When it expires you need to request a new one with your refresh token. We have a guide on refreshing tokens which can be found [here](/api-docs/docs/authentication/refreshtoken/refreshtoken).
 
-Questions? Join the #dev-questions channel on our [discord](https://discord.gg/Glimesh).
+Questions? Join the #dev-questions channel on our [discord](https://glimesh.tv/s/discord).

--- a/content/docs/Authentication/Auth Explained.md
+++ b/content/docs/Authentication/Auth Explained.md
@@ -39,7 +39,7 @@ Authorization: Bearer YOUR_TOKEN
 Access tokens have the below limits:
 
  - Limited by your scopes.
- - Expire in a short period (check the ````expires_in```` when you receive a token, usually 1-6 hours)
+ - Expire in a short period (check the ````expires_in```` when you receive a token, usually 24 hours)
 
 
 ## Obtaining Tokens

--- a/content/docs/Authentication/RefreshToken/RefreshToken.md
+++ b/content/docs/Authentication/RefreshToken/RefreshToken.md
@@ -19,7 +19,7 @@ Refresh tokens are sent when you request an access token. You can pull them from
 }
 ```
 
-You can refresh a token at any time. You do not need to wait for the access token to expire. Refresh tokens last for about one year. When you refresh a token you will need all the info from when you requested an access token.
+You can refresh a token at any time. You do not need to wait for the access token to expire. Refresh tokens last for 1 week. When you refresh a token you will need all the info from when you requested an access token.
 
 Send a POST request to below URL depending on your authentication type:
 
@@ -57,4 +57,4 @@ This will allow you to use the new token and continue to query the Glimesh API. 
  - Refresh tokens last for about 1 year.
  - If a user revokes your dev app you cannot use the access or refresh tokens. This would require the user to authenticate again.
 
-If you have any questions talk to us in the #dev-questions channel in our [Discord](https://discord.gg/Glimesh).
+If you have any questions talk to us in the #dev-questions channel in our [Discord](https://glimesh.tv/s/discord).

--- a/content/docs/Live Updates/Channels.md
+++ b/content/docs/Live Updates/Channels.md
@@ -81,7 +81,7 @@ Since this is a subscription a websocket connection is needed. If you have follo
 ```
 
 
-> Having issues? The [websocket tutorial](/api-docs/docs/chat/websockets/) goes into more detail about the connection. You may find it helpful to complete that tutorial first. If you are still having problems talk to us in [discord](https://discord.gg/Glimesh).
+> Having issues? The [websocket tutorial](/api-docs/docs/chat/websockets/) goes into more detail about the connection. You may find it helpful to complete that tutorial first. If you are still having problems talk to us in [discord](https://glimesh.tv/s/discord).
 
 The above code will connect to Glimesh, subscribe to any changes, and keep us from getting disconnected. To test our code we need to make a change on the channel that we specified. We requested to be sent the current title. Lets change it and see our code in action!
 
@@ -115,4 +115,4 @@ After the title was changed Glimesh sent us the new title.  All properties will 
 
 > Looking for a reference? Click [here](/api-docs/docs/reference/channel/) to view all the channel properties.
 
-If you have any questions talk to us in the #dev-questions channel in our [Discord](https://discord.gg/Glimesh).
+If you have any questions talk to us in the #dev-questions channel in our [Discord](https://glimesh.tv/s/discord).

--- a/content/docs/Live Updates/Followers.md
+++ b/content/docs/Live Updates/Followers.md
@@ -130,4 +130,4 @@ query {
 }
 ```
 
-Stuck with something? Talk to us in [Discord](https://discord.gg/Glimesh). We would be happy to help you!
+Stuck with something? Talk to us in [Discord](https://glimesh.tv/s/discord). We would be happy to help you!

--- a/content/docs/api/API Explorer.md
+++ b/content/docs/api/API Explorer.md
@@ -89,4 +89,4 @@ Insomnia can generate code based on your request to the API. Although the code w
 
 ![Generate Code](https://i.imgur.com/7FCxpAs.png)
 
-This will open a box and you can choose the format and language. If you have any questions about using the Glimesh collection or using the Glimesh API let us know in #dev-questions in our [discord](https://discord.gg/Glimesh).
+This will open a box and you can choose the format and language. If you have any questions about using the Glimesh collection or using the Glimesh API let us know in #dev-questions in our [discord](https://glimesh.tv/s/discord).

--- a/content/docs/api/Query api/Basic Query.md
+++ b/content/docs/api/Query api/Basic Query.md
@@ -83,4 +83,4 @@ ___
 
 
 
-> Stuck with something? Talk to us in [Discord](https://discord.gg/Glimesh). We would be happy to help you!
+> Stuck with something? Talk to us in [Discord](https://glimesh.tv/s/discord). We would be happy to help you!

--- a/content/docs/api/Query api/NodeJS/Node Query.md
+++ b/content/docs/api/Query api/NodeJS/Node Query.md
@@ -123,7 +123,7 @@ When you are ready, **save the file** and type the line below in your terminal t
 
 # Conclusion
 
-This is the basis for most API requests. If you have any questions let us know in the #dev-questions channel in our [Discord](https://Discord.gg/Glimesh).
+This is the basis for most API requests. If you have any questions let us know in the #dev-questions channel in our [Discord](https://glimesh.tv/s/discord).
 
 The full file can be found here.
 ```JS

--- a/content/docs/api/stream/_index.md
+++ b/content/docs/api/stream/_index.md
@@ -1,0 +1,5 @@
+---
+bookCollapseSection: true
+weight: 30
+title: Stream Settings
+---

--- a/content/docs/api/stream/updateStreamInfo.md
+++ b/content/docs/api/stream/updateStreamInfo.md
@@ -1,0 +1,37 @@
+---
+title: Update Stream Info
+---
+
+
+
+# Update Stream Info
+
+Using the new `stream_info` scope we can modify the title of a stream using the Glimesh API. While this scope currently contains 1 mutation, it will be expanded to cover the rest of the stream info fields.
+
+>Before beginning this tutorial you should have a working dev environment and understand the basics of the API.
+
+## Getting Permission
+
+This mutation requires the `stream_info` scope. Any OAuth flow that uses an access token is valid for this query. Simply add the scope to the request:
+```
+scope=stream_info
+```
+> If you don't understand the above explanation take a look at [Auth Explained](/api-docs/docs/authentication/auth-explained). You will need to choose a method of authentication that uses an access token. Set up the request and add the scope. Contact us on [Discord](https://glimesh.tv/s/discord) if you need help!
+
+## Making the Mutation
+
+Each action requires a slightly different mutation. Currently title is the only supported parameter. All mutations require the channel ID to target.
+
+### Updating the Title
+You can request any channel info from the mutation. Here we request the updated title and the channel ID.
+Make the below query
+
+```graphql
+mutation {
+	updateStreamInfo(channelId: 6, title: "Updated from the API, wow, much amaze!") {
+		title,
+		id
+	}
+}
+```
+Note that you cannot make a title longer than 255 characters. Additionally, entering a blank or invalid string will reset the title to its default state (`Live Stream!`).

--- a/content/docs/chat/Chat Tokens.md
+++ b/content/docs/chat/Chat Tokens.md
@@ -141,6 +141,6 @@ Q: What is the difference between this and the normal chat API?
 Q: Should I switch to chat parts?
 > A: That depends on your project. The normal chat API isn't going away so you can use whichever method you like.
 
-If you have more questions feel free to talk to us in our [discord](https://discord.gg/Glimesh)!
+If you have more questions feel free to talk to us in our [discord](https://glimesh.tv/s/discord)!
 
 

--- a/content/docs/chat/Moderation.md
+++ b/content/docs/chat/Moderation.md
@@ -182,4 +182,4 @@ This will return an array of data showing the moderation logs. Moderation logs a
 
 That is the basis for using moderation actions with the API. All of the above queries and mutations can be done through a websocket connection as well as a normal query.
 
-If you have any questions talk to us in the #dev-questions channel in our [Discord](https://discord.gg/Glimesh).
+If you have any questions talk to us in the #dev-questions channel in our [Discord](https://glimesh.tv/s/discord).

--- a/content/docs/chat/Mutations.md
+++ b/content/docs/chat/Mutations.md
@@ -130,4 +130,4 @@ Glimesh will return with the message that was sent to chat. If you want more dat
 }
 ```
 
-This is all of the info required to interact with the chat API. Although this is a viable method, using websockets is the standard way of connecting to the chat. Websockets provide a constant connection and eliminates the need to query the API for new information. This is essential for services such as chatbots. If you have any questions talk to us in our [discord](https://discord.gg/Glimesh).
+This is all of the info required to interact with the chat API. Although this is a viable method, using websockets is the standard way of connecting to the chat. Websockets provide a constant connection and eliminates the need to query the API for new information. This is essential for services such as chatbots. If you have any questions talk to us in our [discord](https://glimesh.tv/s/discord).

--- a/content/docs/chat/Projects/SiteWideSubscription.md
+++ b/content/docs/chat/Projects/SiteWideSubscription.md
@@ -59,4 +59,4 @@ subscription {
 }
 ```
 
-This is all of the info required to listen to every chatroom. If you have any questions talk to us on our [Discord](https://discord.gg/Glimesh).
+This is all of the info required to listen to every chatroom. If you have any questions talk to us on our [Discord](https://glimesh.tv/s/discord).

--- a/content/docs/chat/Websockets.md
+++ b/content/docs/chat/Websockets.md
@@ -30,7 +30,7 @@ Start by opening a secure websocket connection to the URL you are using. When th
 ````
 ["1","1","__absinthe__:control","phx_join",{}]
 ````
-Notice that this is a JSON array. Some WebSocket libraries only allow you to send strings or specially formatted JSON. Sometimes you need to encase the data in a string. If the connection closes immediately you may need to change the type of your request.  This depends purely on your library, if you are having trouble talk to us in our [discord.](https://discord.gg/Glimesh)
+Notice that this is a JSON array. Some WebSocket libraries only allow you to send strings or specially formatted JSON. Sometimes you need to encase the data in a string. If the connection closes immediately you may need to change the type of your request.  This depends purely on your library, if you are having trouble talk to us in our [discord.](https://glimesh.tv/s/discord)
 
 > Javascript example using the ws NPM package:
 >  ```JS
@@ -147,7 +147,7 @@ Glimesh will respond:
 ["1","1","__absinthe__:control","phx_reply",{"response":{"data":{"followers":[{"id":"613","user":{"username":"Mytho"}},{"id":"629","user":{"username":"TheCat"}},{"id":"752","user":{"username":"Kirby"}},{"id":"11992","user":{"username":"RainbowFist"}}]}},"status":"ok"}]
 ```
 
-This is all the info you will need to connect and use the chat API.  If you have any questions talk to us in our [discord!](https://discord.gg/Glimesh)
+This is all the info you will need to connect and use the chat API.  If you have any questions talk to us in our [discord!](https://glimesh.tv/s/discord)
 
 
 ## Connection Issues


### PR DESCRIPTION
This PR adds a doc for using the new `stream_info` scope. It also updates all token refresh times. All Discord invite URLs now use the glimesh.tv link to prevent expired invites.